### PR TITLE
Build xlunch when source changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install: xlunch icons.conf
 test: xlunch
 	./xlunch -g extra/wp.jpg -f "extra/OpenSans-Regular.ttf/10" -c extra/sample_config.cfg
 
-xlunch:
+xlunch: xlunch.c
 	$(CC) xlunch.c -o xlunch $(CFLAGS)
 
 icons.conf:


### PR DESCRIPTION
User should be able to rebuild xlunch when source code changes. Without it, make will say "make: Nothing to be done for 'all'." or "make: 'xlunch' is up to date." if building `make xlunch` only.