### PR TITLE
include fcntl.h for musl

### DIFF
--- a/xlunch.c
+++ b/xlunch.c
@@ -4,6 +4,8 @@
 
 
 #define _GNU_SOURCE
+/* open and O_RDWR,O_CREAT */
+#include <fcntl.h>
 /* include X11 stuff */
 #include <X11/Xlib.h>
 /* include Imlib2 stuff */


### PR DESCRIPTION
This fixes `xlunch` to build with musl libc.
Failing build log:
https://travis-ci.org/voidlinux/void-packages/jobs/233469187