### PR TITLE
Some modifications to the genconf script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ all: xlunch icons.conf
 
 install: xlunch icons.conf
 	mkdir -p $(DESTDIR)/etc/xlunch/
+	mkdir -p $(DESTDIR)/etc/xlunch/svgicons/
 	mkdir -p $(DESTDIR)/usr/bin/
 	cp icons.conf $(DESTDIR)/etc/xlunch/
+	cp -r svgicons/ $(DESTDIR)/etc/xlunch/svgicons/
 	cp extra/ghost.png $(DESTDIR)/usr/share/icons/hicolor/48x48/apps/xlunch_ghost.png
 	cp xlunch $(DESTDIR)/usr/bin/
 

--- a/extra/genconf
+++ b/extra/genconf
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 APPS=/usr/share/applications
+PIXMAPS=/usr/share/pixmaps
 ICONS=/usr/share/icons
 SIZE=48
 
@@ -17,14 +18,23 @@ find $APPS -name "*.desktop" | while read DESKTOPFILE; do
    fi
 
    if [ "$ICONNAME" != "" ]; then
-      ICON="$(find "$ICONS" | grep $SIZE"x"$SIZE | grep $ICONNAME"[.]png" | head -n 1)"
-      if [ "$ICON" != "" -a "$EXEC" != "" -a "$NAME" != "" ]; then
-         echo "$NAME;$ICON;$EXEC"
-      else
-        ICON="$(find "$ICONS" | grep "scalable" | grep -E $ICONNAME"[.](png|svg)" | head -n 1)"
-        if [ "$ICON" != "" -a "$EXEC" != "" -a "$NAME" != "" ]; then
-           echo "$NAME;$ICON;$EXEC"
-        fi
+		  ICON="$(find "$PIXMAPS" | grep $ICONNAME"[.]png" | head -n 1)"
+		  if [ "$ICON" == "" ]; then
+        ICON="$(find "$ICONS" | grep $SIZE"x"$SIZE | grep $ICONNAME"[.]png" | head -n 1)"
+		  fi
+		  if [ "$ICON" == "" ]; then
+        ICON="$(find "$ICONS" | grep "scalable" | grep -E $ICONNAME"[.]png" | head -n 1)"
+				if [ "$ICON" == "" ]; then
+					SVGICON="$(find "$ICONS" | grep "scalable" | grep -E $ICONNAME"[.]svg" | head -n 1)"
+          if [ "$SVGICON" != "" ]; then
+						mkdir -p "svgicons"
+						convert -background none "$SVGICON" "svgicons/"$ICONNAME".png"
+						ICON="svgicons/"$ICONNAME".png"
+					fi
+				fi
       fi
+			if [ "$ICON" != "" -a "$EXEC" != "" -a "$NAME" != "" ]; then
+				 echo "$NAME;$ICON;$EXEC"
+			fi
    fi
 done | sort | uniq

--- a/extra/genconf
+++ b/extra/genconf
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 APPS=/usr/share/applications
-ICONS=/usr/share/icons/hicolor
+ICONS=/usr/share/icons
 SIZE=48
 
 echo "Generating config file from $APPS ..." >&2
@@ -10,19 +10,18 @@ find $APPS -name "*.desktop" | while read DESKTOPFILE; do
    FDATA="$(cat $DESKTOPFILE)"
    NAME="$(echo "$FDATA" | grep -i "^Name=" | head -n 1 | cut -d "=" -f 2-)"
    EXEC="$(echo "$FDATA" | grep -i "^Exec=" | head -n 1 | cut -d "=" -f 2-)"
-   ICON="$(echo "$FDATA" | grep -i "^Icon=" | head -n 1 | cut -d "=" -f 2-)"
+   ICONNAME="$(echo "$FDATA" | grep -i "^Icon=" | head -n 1 | cut -d "=" -f 2-)"
    USETERM="$(echo "$FDATA" | grep -i "^Terminal=" | head -n 1 | cut -d "=" -f 2-)"
-
    if [ "$USETERM" = "true" ]; then
       EXEC="$TERM -e ""$EXEC"
    fi
 
-   if [ "$ICON" != "" ]; then
-      ICON="$(find "$ICONS" | grep $SIZE"x"$SIZE | grep $ICON"[.]png" | head -n 1)"
+   if [ "$ICONNAME" != "" ]; then
+      ICON="$(find "$ICONS" | grep $SIZE"x"$SIZE | grep $ICONNAME"[.]png" | head -n 1)"
       if [ "$ICON" != "" -a "$EXEC" != "" -a "$NAME" != "" ]; then
          echo "$NAME;$ICON;$EXEC"
       else
-        ICON="$(find "$ICONS" | grep "scalable" | grep -E $ICON"[.](png|svg)" | head -n 1)"
+        ICON="$(find "$ICONS" | grep "scalable" | grep -E $ICONNAME"[.](png|svg)" | head -n 1)"
         if [ "$ICON" != "" -a "$EXEC" != "" -a "$NAME" != "" ]; then
            echo "$NAME;$ICON;$EXEC"
         fi


### PR DESCRIPTION
Fixed a bug where ICON got emptied if the first search failed, meaning that the second search would search for a blank icon name. Also added the pixmap path to better comply with the freedesktop standard for icons. And last but not least added automatic conversion of .svg icons into a folder that get's copied into the xlunch install directory (to not pollute the icon folder). This uses imagemagick which adds a dependency so this should probably be optional (and the script should run a check to see if convert exists before running it).