### PR TITLE
Close xlunch when clicking void space

### DIFF
--- a/xlunch.c
+++ b/xlunch.c
@@ -940,13 +940,18 @@ int main(int argc, char **argv)
                   if (ev.xbutton.button==3 && !desktopmode) { cleanup(); exit(0); }
                   if (ev.xbutton.button!=1) break;
                   node_t * current = apps;
+									int clicked = 0;
                   while (current != NULL)
                   {
-                      if (mouse_over_cell(current, ev.xmotion.x, ev.xmotion.y)) setclicked(current,1);
+                      if (mouse_over_cell(current, ev.xmotion.x, ev.xmotion.y)) {
+												setclicked(current,1);
+												clicked = 1;
+											}
                       else setclicked(current,0);
                       current = current->next;
                   }
 
+									if (!clicked) { cleanup(); exit(0); }
                   break;
                }
 

--- a/xlunch.c
+++ b/xlunch.c
@@ -940,18 +940,18 @@ int main(int argc, char **argv)
                   if (ev.xbutton.button==3 && !desktopmode) { cleanup(); exit(0); }
                   if (ev.xbutton.button!=1) break;
                   node_t * current = apps;
-									int clicked = 0;
+                  int clicked = 0;
                   while (current != NULL)
                   {
                       if (mouse_over_cell(current, ev.xmotion.x, ev.xmotion.y)) {
-												setclicked(current,1);
-												clicked = 1;
-											}
+                          setclicked(current,1);
+                          clicked = 1;
+                      }
                       else setclicked(current,0);
                       current = current->next;
                   }
 
-									if (!clicked) { cleanup(); exit(0); }
+                  if (!clicked) { cleanup(); exit(0); }
                   break;
                }
 


### PR DESCRIPTION
As discussed in #3, when clicking anywhere which is not an icon xlunch should close. This allows it to be used on touch-enabled devices.