### PR TITLE
Moved removal of desktop % fields to genconf

### DIFF
--- a/extra/genconf
+++ b/extra/genconf
@@ -10,7 +10,7 @@ echo "Generating config file from $APPS ..." >&2
 find $APPS -name "*.desktop" | while read DESKTOPFILE; do
   FDATA="$(cat $DESKTOPFILE)"
   NAME="$(echo "$FDATA" | grep -i "^Name=" | head -n 1 | cut -d "=" -f 2-)"
-  EXEC="$(echo "$FDATA" | grep -i "^Exec=" | head -n 1 | cut -d "=" -f 2-)"
+  EXEC="$(echo "$FDATA" | grep -i "^Exec=" | head -n 1 | cut -d "=" -f 2- | sed 's/ %[UuFfDdNnickvm]//g')"
   ICONNAME="$(echo "$FDATA" | grep -i "^Icon=" | head -n 1 | cut -d "=" -f 2-)"
   USETERM="$(echo "$FDATA" | grep -i "^Terminal=" | head -n 1 | cut -d "=" -f 2-)"
   if [ "$USETERM" = "true" ]; then

--- a/xlunch.c
+++ b/xlunch.c
@@ -702,23 +702,6 @@ void joincmdlinetext()
 
 void run_command(char * cmd_orig, int excludePercentSign)
 {
-    char cmd[255];
-    strcpy(cmd,cmd_orig);
-
-    // split arguments into pieces
-    int i = 0;
-    char *p = strtok (cmd, " ");
-    char *array[100] = {0};
-
-    if (p==NULL) array[0]=cmd;
-
-    while (p != NULL)
-    {
-        if (strncmp("%",p,1)!=0 || !excludePercentSign) array[i++]=p;
-        p = strtok (NULL, " ");
-        if (i>=99) break;
-    }
-
     restack();
 
     if (desktopmode)
@@ -727,14 +710,14 @@ void run_command(char * cmd_orig, int excludePercentSign)
        if (pid==0) // child process
        {
           if (singleinstance) close(lock);
-          printf("Forking command: %s\n",cmd);
-          int err=execvp(cmd,array);
-          fprintf(stderr,"Error forking %s : %d\n",cmd,err);
+          printf("Forking command: %s\n",cmd_orig);
+          int err=system(cmd_orig);
+          if(err != 0) { fprintf(stderr,"Error running %s : %d\n",cmd_orig,err); }
           exit(0);
        }
        else if (pid<0) // error forking
        {
-          fprintf(stderr,"Error running %s\n",cmd);
+          fprintf(stderr,"Error forking %s\n",cmd_orig);
        }
        else // parent process
        {
@@ -749,9 +732,9 @@ void run_command(char * cmd_orig, int excludePercentSign)
     {
        // execute cmd replacing current process
        cleanup();
-       printf("Running command: %s\n",cmd);
-       int err=execvp(cmd,array);
-       fprintf(stderr,"Error running %s : %d\n",cmd, err);
+       printf("Running command: %s\n",cmd_orig);
+       int err=system(cmd_orig);
+       if(err != 0) { fprintf(stderr,"Error running %s : %d\n",cmd_orig,err); }
        exit(0);
     }
 }


### PR DESCRIPTION
The tokenize and run with `execvp` approach didn't work correctly with queries using quotes as the arguments would be split across multiple ones. This moves the removal of the % fields to the genconf script and simply runs the command found blindly from the C code.