### PR TITLE
 Support (in gentriesquick) if .desktop file names contain spaces 

### DIFF
--- a/extra/gentriesquick
+++ b/extra/gentriesquick
@@ -19,7 +19,7 @@ process_directories()
 
          while read LINE; do
             eval $LINE
-         done <<< $(cat $desktop | egrep '^(Name|Icon|Exec|Hidden|Terminal)=' | sed -r "s/ *%.*//" | sed -r "s/=(.*)/='\\1'/")   #'
+         done <<< $(cat "$desktop" | egrep '^(Name|Icon|Exec|Hidden|Terminal)=' | sed -r "s/ *%.*//" | sed -r "s/=(.*)/='\\1'/")   #'
 
          if [ "$Hidden" = "true" ]; then
             continue

--- a/xlunch.c
+++ b/xlunch.c
@@ -4,7 +4,7 @@
 //          Peter Munch-Ellingsen <www.peterme.net>
 const int VERSION_MAJOR = 3; // Major version, changes when breaking backwards compatability
 const int VERSION_MINOR = 2; // Minor version, changes when new functionality is added
-const int VERSION_PATCH = 9; // Patch version, changes when something is changed without changing deliberate functionality (eg. a bugfix or an optimisation)
+const int VERSION_PATCH = 10; // Patch version, changes when something is changed without changing deliberate functionality (eg. a bugfix or an optimisation)
 
 #define _GNU_SOURCE
 /* open and O_RDWR,O_CREAT */
@@ -2029,9 +2029,6 @@ void handleButtonPress(XEvent ev) {
                     voidclicked = 0;
                 }
                 else set_clicked(current,0);
-                if (++checked == rows*columns) {
-                    break;
-                }
                 current = current->next;
             }
 


### PR DESCRIPTION
Just surrounded `$desktop` on line 22 with double quotes in genentriesquick to make it work for filenames containing spaces.

@PMunch , not sure if I did this right, I see 4 commits, 1 files changed (1 file changed is correct, btw)
EDIT: Well, never mind, is probably OK, just did some commits to my fork and merged with Tomas-M master.